### PR TITLE
Show read-only track list for in progress playlist

### DIFF
--- a/pload/templates/playlist_being_played.html
+++ b/pload/templates/playlist_being_played.html
@@ -1,0 +1,33 @@
+{% extends "base.html" %}
+{% block nav_index %}<li class="nav-item"><a class="nav-link active" href="{{ url_for('pload.index') }}">Scheduled Playlists</a></li>{% endblock %}
+{% block content %}
+<div class="container">
+<h1>Playlist</h1>
+
+<p>This playlist has already started playing and cannot be edited.</p>
+
+<div class="card mt-1">
+    <div class="card-body">
+        <h5 class="card-title">{% if playlist.queue != "prerecorded" %}Playlist{% else %}Prerecorded Show{% endif %}</h5>
+        <p class="card-text">Scheduled to play between {{ playlist.timeslot_start|datetime }} and {{ playlist.timeslot_end|datetime }}.</p>
+    </div>
+
+    <table class="table">
+        <thead>
+            <tr>
+                <th scope="col">URL</th>
+                <th scope="col">Played</th>
+            </tr>
+        </thead>
+        <tbody>
+{% for track in tracks %}
+            <tr>
+                <td><a href="{{ track.url }}">{{ track.url|urldecode|wordwrap }}</a></td>
+                <td>{{ track.played }}</td>
+            </tr>
+{% endfor %}
+        </tbody>
+    </table>
+</div>
+</div>
+{% endblock %}

--- a/pload/views.py
+++ b/pload/views.py
@@ -367,8 +367,11 @@ def edit_playlist(playlist_id):
     # Make sure no tracks in the playlist have been played yet
     for track in tracks.all():
         if track.played:
-            # FIXME
-            abort(400)
+            return render_template(
+                "playlist_being_played.html",
+                playlist=playlist,
+                tracks=[t.serialize() for t in tracks.all()],
+            )
 
     return render_template(
         "edit_playlist.html",


### PR DESCRIPTION
If one of the tracks in the playlist is marked as played, we currently
display an error message. Instead, let's show a list of tracks along
with whether or not the track is marked as played. This also works for
playlists that have completed.

Fixes #4.