### PR TITLE
Disable "save changes" button while saving

### DIFF
--- a/pload/static/js/playlist_editor.js
+++ b/pload/static/js/playlist_editor.js
@@ -459,6 +459,7 @@ PlaylistEditor.prototype.initImport = function() {
                             });
                         } catch(error) {
                             alert(errorMsg);
+                            $('#save_changes_btn').prop('disabled', false);
                             return;
                         }
 

--- a/pload/templates/edit_playlist.html
+++ b/pload/templates/edit_playlist.html
@@ -9,6 +9,8 @@ playlistEditor.init();
 playlistEditor.loadPlaylist({{ tracks|tojson }});
 
 $('#save_changes_btn').on('click', function(ev) {
+    $('#save_changes_btn').prop('disabled', true);
+
     $.ajax({
         url: "{{ url_for('pload.edit_playlist', playlist_id=playlist.id) }}",
         method: "POST",
@@ -26,6 +28,12 @@ $('#save_changes_btn').on('click', function(ev) {
                     alert("An error occurred while saving the playlist.");
                 }
             }
+
+            $('#save_changes_btn').prop('disabled', false);
+        },
+        error: function(data) {
+            alert("An error occurred while saving the playlist.");
+            $('#save_changes_btn').prop('disabled', false);
         },
     });
 });

--- a/pload/templates/playlist_editor.html
+++ b/pload/templates/playlist_editor.html
@@ -183,5 +183,5 @@
 {% endblock %}
 {% block js %}
 {{ super() }}
-<script src="{{ url_for('static', filename='js/playlist_editor.js', v=8) }}"></script>
+<script src="{{ url_for('static', filename='js/playlist_editor.js', v=9) }}"></script>
 {% endblock %}


### PR DESCRIPTION
Apparently some users have been getting impatient and clicking this button multiple times. This causes requests to race each other and can lead the same tracks being added multiple times to the same playlist.

I've also pulled in a fix to reenable the save changes button after import when there's an HTTP error.