### PR TITLE
Add playlist delete button (fixes #51)

### DIFF
--- a/pload/api.py
+++ b/pload/api.py
@@ -33,7 +33,7 @@ def next_track():
         Playlist.timeslot_start <= now,
         Playlist.timeslot_end > now,
         Playlist.queue == queue,
-        # Playlist.approved != None,
+        Playlist.approved != None,
     ).first()
     if playlist is not None:
         next_track = (

--- a/pload/forms.py
+++ b/pload/forms.py
@@ -54,7 +54,6 @@ class CreatePlaylistForm(FlaskForm):
     time_end = TimeField(
         "End Time", validators=[validators.InputRequired()], widget=BootstrapTimeInput()
     )
-    overwrite = BooleanField("Overwrite the existing playlist (if one exists)")
     dj_id = SelectField("DJ", choices=[("1", "Automation")], widget=BootstrapSelect())
 
     def validate_date(self, field):

--- a/pload/templates/create_playlist.html
+++ b/pload/templates/create_playlist.html
@@ -57,11 +57,6 @@
         </div>
     </div>
 
-    <div class="form-group row form-check">
-        {{ form.overwrite(class_="form-check-input") }}
-        {{ form.overwrite.label(class_="form-check-label") }}
-    </div>
-
     <div class="form-actions">
         <button type="submit" class="btn btn-primary">
             Create

--- a/pload/templates/index.html
+++ b/pload/templates/index.html
@@ -13,23 +13,23 @@
     <table class="table table-striped table-hover">
         <thead>
             <th scope="col" width="25%"></th>
-            <th scope="col" width="40%">DJ</th>
+            <th scope="col" width="35%">DJ</th>
             <th scope="col" width="10%">Tracks</th>
             <th scope="col" width="10%">Start Time</th>
             <th scope="col" width="10%">End Time</th>
-            <th scope="col" width="5%"></th>
+            <th scope="col" width="10%"></th>
         </thead>
         <tbody>
 {% for playlist in playlists %}
-            <tr>
+            <tr data-playlist-id="{{ playlist.id }}">
                 <td>{% if playlist.queue != "prerecorded" %}Playlist{% else %}Prerecorded Show{% endif %}</td>
                 <td>{{ playlist.dj }}</td>
                 <td>{{ playlist.track_count }}</td>
                 <td>{{ playlist.timeslot_start|datetime("%H:%M", False) }}</td>
                 <td>{{ playlist.timeslot_end|datetime("%H:%M", False) }}</td>
-                <td>
+                <td class="text-right">
                     <a href="{{ url_for('pload.edit_playlist', playlist_id=playlist.id) }}" class="btn btn-secondary btn-sm playlist-edit" title="Edit this playlist"><span class="oi oi-pencil"></span></a>
-                    {# TODO: delete playlist #}
+                    <button class="btn btn-danger btn-sm playlist-delete" title="Delete this playlist"><span class="oi oi-trash"></span></button>
                 </td>
             </tr>
 {% endfor %}
@@ -37,4 +37,37 @@
     </table>
 </div>
 {% endfor %}
+{% endblock %}
+{% block js %}
+{{ super() }}
+<script nonce="{{ script_nonce }}">
+$('button.playlist-delete').on('click', function(ev) {
+    var row = $(this).parents('tr');
+    var playlistId = row.attr('data-playlist-id');
+
+    if(!confirm("Are you sure you want to delete the selected playlist?")) {
+        return;
+    }
+
+    $.ajax({
+        url: "/playlists/edit/" + playlistId,
+        method: "DELETE",
+        dataType: "json",
+        success: function(data) {
+            if(data['success']) {
+                row.remove();
+            } else {
+                if(typeof data['message'] != 'undefined') {
+                    alert(data['message']);
+                } else {
+                    alert("An error occurred while deleting that playlist.");
+                }
+            }
+        },
+        error: function(data) {
+            alert("An error occurred while deleting that playlist.");
+        },
+    });
+});
+</script>
 {% endblock %}

--- a/pload/views.py
+++ b/pload/views.py
@@ -46,7 +46,10 @@ def index():
             tracks_sq.c.count,
         )
         .join(tracks_sq, tracks_sq.c.playlist_id == Playlist.id)
-        .filter(Playlist.timeslot_end >= datetime.datetime.utcnow(),)
+        .filter(
+            Playlist.timeslot_end >= datetime.datetime.utcnow(),
+            Playlist.approved != None,
+        )
         .order_by(Playlist.timeslot_start)
         .all()
     )
@@ -159,6 +162,28 @@ def edit_playlist(playlist_id):
     )
 
 
+@bp.route("/playlists/edit/<int:playlist_id>", methods=["DELETE"])
+def delete_playlist(playlist_id):
+    playlist = Playlist.query.get_or_404(playlist_id)
+
+    # Make sure no tracks in the playlist have been played yet
+    for track in playlist.tracks.all():
+        if track.played:
+            return jsonify(
+                {
+                    "success": False,
+                    "message": "One or more tracks in the playlist have already been played.",
+                }
+            )
+
+    # No tracks have been played, so mark the playlist as not approved
+    # We do this instead of deleting to enable restoration of deleted playlists
+    # if necessary
+    playlist.approved = None
+    db.session.commit()
+    return jsonify({"success": True,})
+
+
 @bp.route("/playlists/new", methods=["GET", "POST"])
 def create_playlist():
     form = CreatePlaylistForm()
@@ -203,26 +228,21 @@ def create_playlist():
             Playlist.timeslot_start >= timeslot_start,
             Playlist.timeslot_end <= timeslot_end,
             Playlist.queue == queue,
+            Playlist.approved != None,
         )
 
-        # check if overwriting is necessary
-        if existing_playlists.count() > 0 and not form.overwrite.data:
+        # check for existing playlists in the same slot
+        if existing_playlists.count() > 0:
             flash(
                 """\
 A playlist already exists for that date and time slot. You'll need to either
-overwrite the existing playlist, or pick another date or time slot."""
+delete the existing playlist or pick a different slot."""
             )
         else:
-            # We're overwriting, so delete all tracks for all matching
-            # playlists
-            for playlist in existing_playlists.all():
-                for track in playlist.tracks:
-                    db.session.delete(track)
-                db.session.delete(playlist)
-
             playlist = Playlist(
                 timeslot_start, timeslot_end, form.dj_id.data, form.queue.data
             )
+            playlist.approved = datetime.datetime.utcnow()
             db.session.add(playlist)
 
             db.session.commit()


### PR DESCRIPTION
This change removes the "overwrite existing playlist" checkbox and
instead adds a playlist delete button. It doesn't delete the playlist
from the database but instead marks it as unapproved, allowing us to
retrieve inadvertently deleted playlists if necessary.

![Create playlist view](https://user-images.githubusercontent.com/67266/90970394-466f3f80-e4b9-11ea-94b1-fa69142911f8.png)
![Index view](https://user-images.githubusercontent.com/67266/90970398-4ec77a80-e4b9-11ea-8adc-db816a63e115.png)
![Delete confirmation](https://user-images.githubusercontent.com/67266/90970950-d87a4680-e4bf-11ea-9fe9-978f4c8f6bc6.png)

