### PR TITLE
Check that date is provided when creating playlist

### DIFF
--- a/pload/forms.py
+++ b/pload/forms.py
@@ -57,5 +57,7 @@ class CreatePlaylistForm(FlaskForm):
     dj_id = SelectField("DJ", choices=[("1", "Automation")], widget=BootstrapSelect())
 
     def validate_date(self, field):
+        if not isinstance(field.data, datetime.date):
+            raise ValidationError("A date must be provided.")
         if field.data < datetime.datetime.now(get_slot_tz()).date():
             raise ValidationError("The date cannot be in the past.")


### PR DESCRIPTION
We currently do client-side checking for this, but if someone gets past
this, failure to provide a date will result in a 500 error instead of a
400 error. Instead, do a server-side check to ensure that the correct
error code is thrown and exceptions do not end up in our logs.