### PR TITLE
Highlight tracks that failed when saving

### DIFF
--- a/pload/templates/edit_playlist.html
+++ b/pload/templates/edit_playlist.html
@@ -27,6 +27,17 @@ $('#save_changes_btn').on('click', function(ev) {
                 } else {
                     alert("An error occurred while saving the playlist.");
                 }
+
+                // highlight tracks that failed, if they are present in the response
+                if(typeof data['results'] == 'object') {
+                    for(let i = 0; i < data['results'].length; i++) {
+                        let row = $('#playlist tr[data-playlist-id=' + i + ']');
+                        if(typeof row != 'undefined') {
+                            row.addClass('table-danger');
+                            row.attr('title', "An error occurred with this track. Please double check it and try again.");
+                        }
+                    }
+                }
             }
 
             $('#save_changes_btn').prop('disabled', false);


### PR DESCRIPTION
Normally, it shouldn't be possible for this to happen as each track is
validated before the playlist is saved. This can happen, however, if
tracks are deleted from the underlying source before saving. If that
happens, give the user some indication of what actually went wrong by
highlighting the tracks and adding a tooltip.

Fixes #65.

![Screenshot showing a highlighted track](https://user-images.githubusercontent.com/67266/104156446-e876c200-539d-11eb-8aef-97175a2cd6ff.png)
